### PR TITLE
タグをキャプションの中に書いて、DBに保存し、ビューに反映させるところまで実装

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,7 @@
 module PostsHelper
+
+  def render_with_hashtags(caption)
+    caption.gsub(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/){|word| link_to word, "/post/hashtag/#{word.delete("#")}"}.html_safe
+  end
+  
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -23,7 +23,7 @@ module PostsHelper
     last_cap = caption[(hash_point.last[1] + 1)..-1]
     cap_arr.push(last_cap)
     cap_arr.map do |word|
-      if word.match(Hashtag.hashtag_source_of_judgment)
+      if word.match(Hashtag::HASHTAG_CONDITIONS)
         delete_pound_word = Hashtag.pound_delete_at_hashtag(word)
         link_to word, "/post/hashtag/" + delete_pound_word
       else

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,10 +1,17 @@
 module PostsHelper
   def render_with_hashtags(caption)
-    if caption.match(/[#＃]/)
-      hashtags = caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
+    hashtags = caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
+    if hashtags.present?
+      dup_hash = Hash.new{ |word, bottom_point| }
+      hashtags.uniq.each do |word|
+        top_point = caption.index(word)
+        bottom_point = caption.index(word) + word.length - 1
+        dup_hash.store(word, 0)
+      end
       hash_point = hashtags.map do |num|
-        top_point = caption.index(num)
-        bottom_point = caption.index(num) + num.length - 1
+        top_point = caption.index(num, dup_hash[num])
+        bottom_point = caption.index(num, dup_hash[num]) + num.length - 1
+        dup_hash.store(num, bottom_point)
         hash = []
         hash.push(top_point, bottom_point)
       end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,5 +1,36 @@
 module PostsHelper
   def render_with_hashtags(caption)
-    caption.gsub(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/){|word| link_to word, "/post/hashtag/#{word.delete("#")}"}.html_safe
+    if caption.match(/[#＃]/)
+      hashtags = caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
+      hash_point = hashtags.map do |num|
+        top_point = caption.index(num)
+        bottom_point = caption.index(num) + num.length - 1
+        hash = []
+        hash.push(top_point, bottom_point)
+      end
+      cap_hash = []
+      cap_arr = hash_point.each_with_index do |arr, i|
+        if i == 0
+          front_cap = caption[0...arr[0]]
+          cap_hash.push(front_cap)
+        else
+          space_cap = caption[(hash_point[i-1][1] + 1)...hash_point[i][0]]
+          cap_hash.push(space_cap)
+        end
+        tag = caption[arr[0]..arr[1]]
+        cap_hash.push(tag)
+      end
+      last_cap = caption[(hash_point.last[1] + 1)..-1]
+      cap_hash.push(last_cap)
+      cap_link = cap_hash.map do |word|
+        if word.match(/[#＃]/)
+          p link_to word, "/post/hashtag/#{word.delete("#")}"
+        else
+          p word
+        end
+      end
+    else
+      p caption
+    end
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -14,7 +14,7 @@ module PostsHelper
       dup_hash[num] = bottom_point
       [top_point, bottom_point]
     end
-    cap_arr = [first_cap = caption[0...hash_point[0][0]]]
+    cap_arr = [caption[0...hash_point[0][0]]]
     hash_point.each_with_index do |arr, i|
       tag = caption[arr[0]..arr[1]]
       usually_cap = caption[(hash_point[i-1][1] + 1)...hash_point[(i)][0]]

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,43 +1,43 @@
 module PostsHelper
-  def render_with_hashtags(caption)
-    hashtags = caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
-    if hashtags.present?
-      dup_hash = Hash.new{ |word, bottom_point| }
-      hashtags.uniq.each do |word|
-        top_point = caption.index(word)
-        bottom_point = caption.index(word) + word.length - 1
-        dup_hash.store(word, 0)
-      end
-      hash_point = hashtags.map do |num|
-        top_point = caption.index(num, dup_hash[num])
-        bottom_point = caption.index(num, dup_hash[num]) + num.length - 1
-        dup_hash.store(num, bottom_point)
-        hash = []
-        hash.push(top_point, bottom_point)
-      end
-      cap_hash = []
-      cap_arr = hash_point.each_with_index do |arr, i|
-        if i == 0
-          front_cap = caption[0...arr[0]]
-          cap_hash.push(front_cap)
+  def return_an_array(caption)
+    hashtags = Post.hashtag_scan(caption)
+    dup_hash = {}
+    hashtags.uniq.each do |word|
+      dup_hash[word] = 0
+    end
+    hash_point = hashtags.map do |num|
+      top_point = caption.index(num, dup_hash[num])
+      bottom_point = caption.index(num, dup_hash[num]) + num.length - 1
+      dup_hash[num] = bottom_point
+      hash_point =  top_point, bottom_point
+    end
+    cap_arr = []
+    hash_point.each_with_index do |arr, i|
+      usually_cap = caption[
+        if cap_arr.empty?
+          0...hash_point[0][0]
         else
-          space_cap = caption[(hash_point[i-1][1] + 1)...hash_point[i][0]]
-          cap_hash.push(space_cap)
+          (hash_point[i-1][1] + 1)...hash_point[i][0]
         end
-        tag = caption[arr[0]..arr[1]]
-        cap_hash.push(tag)
+      ]
+      tag = caption[arr[0]..arr[1]]
+      cap_arr.push(usually_cap, tag)
+    end
+    last_cap = caption[
+      if caption.match(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
+        (hash_point.last[1] + 1)..-1
+      else
+        0..-1
       end
-      last_cap = caption[(hash_point.last[1] + 1)..-1]
-      cap_hash.push(last_cap)
-      cap_link = cap_hash.map do |word|
-        if word.match(/[#＃]/)
-          p link_to word, "/post/hashtag/#{word.delete("#")}"
-        else
-          p word
-        end
+    ]
+    cap_arr.push(last_cap)
+    cap_arr.map do |word|
+      if word.match(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
+        delete_pound_word = word.delete(word[0])
+        p link_to word, "/post/hashtag/" + delete_pound_word
+      else
+        p word
       end
-    else
-      p caption
     end
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -20,8 +20,7 @@ module PostsHelper
       usually_cap = caption[(hash_point[i-1][1] + 1)...hash_point[(i)][0]]
       cap_arr.push(usually_cap, tag)
     end
-    last_cap = caption[(hash_point.last[1] + 1)..-1]
-    cap_arr.push(last_cap)
+    cap_arr.push(caption[(hash_point.last[1] + 1)..-1])
     cap_arr.map do |word|
       if word.match(Hashtag::HASHTAG_CONDITIONS)
         delete_pound_word = Hashtag.pound_delete_at_hashtag(word)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,7 +1,5 @@
 module PostsHelper
-
   def render_with_hashtags(caption)
     caption.gsub(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/){|word| link_to word, "/post/hashtag/#{word.delete("#")}"}.html_safe
   end
-  
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,42 +1,36 @@
 module PostsHelper
-  def return_an_array(caption)
+  def output_array(caption)
     hashtags = Post.hashtag_scan(caption)
-    dup_hash = {}
-    hashtags.uniq.each do |word|
-      dup_hash[word] = 0
-    end
-    hash_point = hashtags.map do |num|
-      top_point = caption.index(num, dup_hash[num])
-      bottom_point = caption.index(num, dup_hash[num]) + num.length - 1
-      dup_hash[num] = bottom_point
-      hash_point =  top_point, bottom_point
-    end
     cap_arr = []
-    hash_point.each_with_index do |arr, i|
-      usually_cap = caption[
-        if cap_arr.empty?
-          0...hash_point[0][0]
-        else
-          (hash_point[i-1][1] + 1)...hash_point[i][0]
-        end
-      ]
-      tag = caption[arr[0]..arr[1]]
-      cap_arr.push(usually_cap, tag)
-    end
-    last_cap = caption[
-      if caption.match(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
-        (hash_point.last[1] + 1)..-1
-      else
-        0..-1
+    unless hashtags.present?
+      cap_arr.push(caption[0..-1])
+    else
+      dup_hash = {}
+      hashtags.uniq.each do |word|
+        dup_hash[word] = 0
       end
-    ]
-    cap_arr.push(last_cap)
+      hash_point = hashtags.map do |num|
+        top_point = caption.index(num, dup_hash[num])
+        bottom_point = caption.index(num, dup_hash[num]) + num.length - 1
+        dup_hash[num] = bottom_point
+        [top_point, bottom_point]
+      end
+      first_cap = caption[0...hash_point[0][0]]
+      cap_arr.push(first_cap)
+      hash_point.each_with_index do |arr, i|
+        tag = caption[arr[0]..arr[1]]
+        usually_cap = caption[(hash_point[i-1][1] + 1)...hash_point[(i)][0]]
+        cap_arr.push(usually_cap, tag)
+      end
+      last_cap = caption[(hash_point.last[1] + 1)..-1]
+      cap_arr.push(last_cap)
+    end
     cap_arr.map do |word|
-      if word.match(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
-        delete_pound_word = word.delete(word[0])
-        p link_to word, "/post/hashtag/" + delete_pound_word
+      if word.match(Post.regular_expressions)
+        delete_pound_word = word.delete("[#＃]")
+        link_to word, "/post/hashtag/" + delete_pound_word
       else
-        p word
+        word
       end
     end
   end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,33 +1,32 @@
 module PostsHelper
-  def output_array(caption)
-    hashtags = Post.hashtag_scan(caption)
-    cap_arr = []
-    unless hashtags.present?
-      cap_arr.push(caption[0..-1])
-    else
-      dup_hash = {}
-      hashtags.uniq.each do |word|
-        dup_hash[word] = 0
-      end
-      hash_point = hashtags.map do |num|
-        top_point = caption.index(num, dup_hash[num])
-        bottom_point = caption.index(num, dup_hash[num]) + num.length - 1
-        dup_hash[num] = bottom_point
-        [top_point, bottom_point]
-      end
-      first_cap = caption[0...hash_point[0][0]]
-      cap_arr.push(first_cap)
-      hash_point.each_with_index do |arr, i|
-        tag = caption[arr[0]..arr[1]]
-        usually_cap = caption[(hash_point[i-1][1] + 1)...hash_point[(i)][0]]
-        cap_arr.push(usually_cap, tag)
-      end
-      last_cap = caption[(hash_point.last[1] + 1)..-1]
-      cap_arr.push(last_cap)
+  def caption_and_hashtags_in_array(caption)
+    hashtags = Hashtag.hashtag_scan(caption)
+    if hashtags.blank?
+      return [caption[0..-1]]
     end
+    dup_hash = {}
+    hashtags.uniq.each do |word|
+      dup_hash[word] = 0
+    end
+    hash_point = hashtags.map do |num|
+      top_point = caption.index(num, dup_hash[num])
+      bottom_point = caption.index(num, dup_hash[num]) + num.length - 1
+      dup_hash[num] = bottom_point
+      [top_point, bottom_point]
+    end
+    cap_arr = []
+    first_cap = caption[0...hash_point[0][0]]
+    cap_arr.push(first_cap)
+    hash_point.each_with_index do |arr, i|
+      tag = caption[arr[0]..arr[1]]
+      usually_cap = caption[(hash_point[i-1][1] + 1)...hash_point[(i)][0]]
+      cap_arr.push(usually_cap, tag)
+    end
+    last_cap = caption[(hash_point.last[1] + 1)..-1]
+    cap_arr.push(last_cap)
     cap_arr.map do |word|
-      if word.match(Post.regular_expressions)
-        delete_pound_word = word.delete("[#＃]")
+      if word.match(Hashtag.hashtag_source_of_judgment)
+        delete_pound_word = Hashtag.pound_delete_at_hashtag(word)
         link_to word, "/post/hashtag/" + delete_pound_word
       else
         word

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,7 +2,7 @@ module PostsHelper
   def caption_and_hashtags_in_array(caption)
     hashtags = Hashtag.hashtag_scan(caption)
     if hashtags.blank?
-      return [caption[0..-1]]
+      return [caption]
     end
     dup_hash = {}
     hashtags.uniq.each do |word|
@@ -14,9 +14,7 @@ module PostsHelper
       dup_hash[num] = bottom_point
       [top_point, bottom_point]
     end
-    cap_arr = []
-    first_cap = caption[0...hash_point[0][0]]
-    cap_arr.push(first_cap)
+    cap_arr = [first_cap = caption[0...hash_point[0][0]]]
     hash_point.each_with_index do |arr, i|
       tag = caption[arr[0]..arr[1]]
       usually_cap = caption[(hash_point[i-1][1] + 1)...hash_point[(i)][0]]

--- a/app/models/hashtag.rb
+++ b/app/models/hashtag.rb
@@ -1,2 +1,5 @@
 class Hashtag < ApplicationRecord
+  has_many :post_taggings, dependent: :destroy
+  has_many :posts, through: :post_taggings
+  validates :label, presence: true, length: { maximum: 50 }
 end

--- a/app/models/hashtag.rb
+++ b/app/models/hashtag.rb
@@ -2,15 +2,12 @@ class Hashtag < ApplicationRecord
   has_many :post_taggings, dependent: :destroy
   has_many :posts, through: :post_taggings
   validates :label, presence: true, length: { maximum: 50 }
-  Hashtag_conditions = %r{[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+}
-  Lead_pound = %r{[#＃]}
-  def self.hashtag_source_of_judgment
-    Hashtag_conditions
-  end
+  LEAD_POUND = %r{[#＃]}
+  HASHTAG_CONDITIONS = %r{#{LEAD_POUND}[\w\p{Han}ぁ-ヶｦ-ﾟー]+}
   def self.hashtag_scan(caption)
-    caption.scan(hashtag_source_of_judgment)
+    caption.scan(HASHTAG_CONDITIONS)
   end
   def self.pound_delete_at_hashtag(word)
-    word.gsub(Lead_pound, '')
+    word.gsub(LEAD_POUND, '')
   end
 end

--- a/app/models/hashtag.rb
+++ b/app/models/hashtag.rb
@@ -2,12 +2,13 @@ class Hashtag < ApplicationRecord
   has_many :post_taggings, dependent: :destroy
   has_many :posts, through: :post_taggings
   validates :label, presence: true, length: { maximum: 50 }
-  LEAD_POUND = %r{[#＃]}
+  LEAD_POUND = "[#＃]"
   HASHTAG_CONDITIONS = %r{#{LEAD_POUND}[\w\p{Han}ぁ-ヶｦ-ﾟー]+}
+  p HASHTAG_CONDITIONS
   def self.hashtag_scan(caption)
     caption.scan(HASHTAG_CONDITIONS)
   end
   def self.pound_delete_at_hashtag(word)
-    word.gsub(LEAD_POUND, '')
+    word.gsub(/#{LEAD_POUND}/, '')
   end
 end

--- a/app/models/hashtag.rb
+++ b/app/models/hashtag.rb
@@ -2,4 +2,14 @@ class Hashtag < ApplicationRecord
   has_many :post_taggings, dependent: :destroy
   has_many :posts, through: :post_taggings
   validates :label, presence: true, length: { maximum: 50 }
+
+  def self.hashtag_source_of_judgment
+    /[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/
+  end
+  def self.hashtag_scan(caption)
+    caption.scan(hashtag_source_of_judgment)
+  end
+  def self.pound_delete_at_hashtag(word)
+    word.gsub(/[#＃]/, '')
+  end
 end

--- a/app/models/hashtag.rb
+++ b/app/models/hashtag.rb
@@ -4,7 +4,6 @@ class Hashtag < ApplicationRecord
   validates :label, presence: true, length: { maximum: 50 }
   LEAD_POUND = "[#＃]"
   HASHTAG_CONDITIONS = %r{#{LEAD_POUND}[\w\p{Han}ぁ-ヶｦ-ﾟー]+}
-  p HASHTAG_CONDITIONS
   def self.hashtag_scan(caption)
     caption.scan(HASHTAG_CONDITIONS)
   end

--- a/app/models/hashtag.rb
+++ b/app/models/hashtag.rb
@@ -2,14 +2,15 @@ class Hashtag < ApplicationRecord
   has_many :post_taggings, dependent: :destroy
   has_many :posts, through: :post_taggings
   validates :label, presence: true, length: { maximum: 50 }
-
+  Hashtag_conditions = %r{[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+}
+  Lead_pound = %r{[#＃]}
   def self.hashtag_source_of_judgment
-    /[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/
+    Hashtag_conditions
   end
   def self.hashtag_scan(caption)
     caption.scan(hashtag_source_of_judgment)
   end
   def self.pound_delete_at_hashtag(word)
-    word.gsub(/[#＃]/, '')
+    word.gsub(Lead_pound, '')
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,15 +13,17 @@ class Post < ApplicationRecord
   def liked_by(user)
     Like.find_by(user_id: user.id, post_id: id)
   end
-  
-  private
-  def self.hashtag_scan(caption)
-    caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
+  def self.regular_expressions
+    /[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/
   end
+  def self.hashtag_scan(caption)
+    caption.scan(regular_expressions)
+  end
+  private
   def generate_hashtag
     post_labels = Post.hashtag_scan(caption)
     post_labels.uniq.each do |hashtag|
-      self.hashtags << Hashtag.find_or_create_by(label: hashtag.delete('#'))
+      self.hashtags << Hashtag.find_or_create_by(label: hashtag.delete("[#＃]"))
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,17 +13,11 @@ class Post < ApplicationRecord
   def liked_by(user)
     Like.find_by(user_id: user.id, post_id: id)
   end
-  def self.regular_expressions
-    /[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/
-  end
-  def self.hashtag_scan(caption)
-    caption.scan(regular_expressions)
-  end
   private
   def generate_hashtag
-    post_labels = Post.hashtag_scan(caption)
-    post_labels.uniq.each do |hashtag|
-      self.hashtags << Hashtag.find_or_create_by(label: hashtag.delete("[#＃]"))
+    post_labels = Hashtag.hashtag_scan(caption)
+    post_labels.uniq.each do |word|
+      self.hashtags << Hashtag.find_or_create_by(label: Hashtag.pound_delete_at_hashtag(word))
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,15 +14,14 @@ class Post < ApplicationRecord
     Like.find_by(user_id: user.id, post_id: id)
   end
 
+  private
   def hashtag_scan
     caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
   end
-
-  private
-    def generate_hashtag
-      post_labels = self.hashtag_scan
-      post_labels.uniq.map do |hashtag|
-      self.hashtags <<  Hashtag.find_or_create_by(label: hashtag.delete('#'))
+  def generate_hashtag
+    post_labels = hashtag_scan
+    post_labels.uniq.each do |hashtag|
+      self.hashtags << Hashtag.find_or_create_by(label: hashtag.delete('#'))
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,13 +13,13 @@ class Post < ApplicationRecord
   def liked_by(user)
     Like.find_by(user_id: user.id, post_id: id)
   end
-
+  
   private
-  def hashtag_scan
+  def self.hashtag_scan(caption)
     caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
   end
   def generate_hashtag
-    post_labels = hashtag_scan
+    post_labels = Post.hashtag_scan(caption)
     post_labels.uniq.each do |hashtag|
       self.hashtags << Hashtag.find_or_create_by(label: hashtag.delete('#'))
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,30 +8,21 @@ class Post < ApplicationRecord
   has_many :hashtags, through: :post_taggings
 
   accepts_nested_attributes_for :photos
+  after_create :generate_hashtag
 
   def liked_by(user)
     Like.find_by(user_id: user.id, post_id: id)
   end
 
-  after_create do
-    # 作成した投稿を探す
-    post = Post.find_by(id: self.id)
-    hashtags = post.caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
-    hashtags.uniq.map do |hashtag|
-      # ハッシュタグは先頭の'#'を外した上で保存するようにする
-      tag = Hashtag.find_or_create_by(label: hashtag.downcase.delete('#'))
-      post.hashtags << tag
-    end
+  def hashtag_scan
+    caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
   end
 
-  before_update do 
-    post = Post.find_by(id: self.id)
-    post.hashtags.clear
-    hashtags = post.caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
-    hashtags.uniq.map do |hashtag|
-      tag = Hashtag.find_or_create_by(label: hashtag.downcase.delete('#'))
-      post.hashtags << tag
+  private
+    def generate_hashtag
+      post_labels = self.hashtag_scan
+      post_labels.uniq.map do |hashtag|
+      self.hashtags <<  Hashtag.find_or_create_by(label: hashtag.delete('#'))
     end
   end
-  
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,9 +4,34 @@ class Post < ApplicationRecord
   has_many :likes, -> { order(created_at: :desc) }, dependent: :destroy
   has_many :comments, dependent: :destroy
 
+  has_many :post_taggings, dependent: :destroy
+  has_many :hashtags, through: :post_taggings
+
   accepts_nested_attributes_for :photos
 
   def liked_by(user)
     Like.find_by(user_id: user.id, post_id: id)
   end
+
+  after_create do
+    # 作成した投稿を探す
+    post = Post.find_by(id: self.id)
+    hashtags = post.caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
+    hashtags.uniq.map do |hashtag|
+      # ハッシュタグは先頭の'#'を外した上で保存するようにする
+      tag = Hashtag.find_or_create_by(label: hashtag.downcase.delete('#'))
+      post.hashtags << tag
+    end
+  end
+
+  before_update do 
+    post = Post.find_by(id: self.id)
+    post.hashtags.clear
+    hashtags = post.caption.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)
+    hashtags.uniq.map do |hashtag|
+      tag = Hashtag.find_or_create_by(label: hashtag.downcase.delete('#'))
+      post.hashtags << tag
+    end
+  end
+  
 end

--- a/app/models/post_tagging.rb
+++ b/app/models/post_tagging.rb
@@ -1,4 +1,6 @@
 class PostTagging < ApplicationRecord
   belongs_to :post
   belongs_to :hashtag
+  validates :post_id, presence: true
+  validates :hashtag_id, presence: true
 end

--- a/app/models/post_tagging.rb
+++ b/app/models/post_tagging.rb
@@ -3,4 +3,5 @@ class PostTagging < ApplicationRecord
   belongs_to :hashtag
   validates :post_id, presence: true
   validates :hashtag_id, presence: true
+  validates :post_id, uniqueness: { scope: :hashtag_id }
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -37,8 +37,8 @@
           <div>
             <span><strong><%= post.user.name %></strong></span>
             <span>
-              <% return_an_array(post.caption).each do |word| %>
-                <%= p word %>
+              <% output_array(post.caption).each do |word| %>
+                <%= word %>
               <% end %>
             </span>
             <%= link_to time_ago_in_words(post.created_at).upcase + "前", post_path(post), class: "post-time no-text-decoration" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -37,12 +37,8 @@
           <div>
             <span><strong><%= post.user.name %></strong></span>
             <span>
-              <% if post.caption.match(/[#＃]/) %>
-                <% render_with_hashtags(post.caption).each do |word| %>
-                  <%= p word %>
-                <% end %>
-              <% else %>
-                <%= p post.caption %>
+              <% return_an_array(post.caption).each do |word| %>
+                <%= p word %>
               <% end %>
             </span>
             <%= link_to time_ago_in_words(post.created_at).upcase + "前", post_path(post), class: "post-time no-text-decoration" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -37,7 +37,7 @@
           <div>
             <span><strong><%= post.user.name %></strong></span>
             <span>
-              <% output_array(post.caption).each do |word| %>
+              <% caption_and_hashtags_in_array(post.caption).each do |word| %>
                 <%= word %>
               <% end %>
             </span>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -44,7 +44,7 @@
 
           <div>
             <span><strong><%= post.user.name %></strong></span>
-            <span><%= post.caption %></span>
+            <span><%= render_with_hashtags(post.caption) %></span>
             <%= link_to time_ago_in_words(post.created_at).upcase + "前", post_path(post), class: "post-time no-text-decoration" %>
             
             <div id="comment-post-<%= post.id.to_s %>">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,23 +10,18 @@
             title: post.user.name do %>
             <strong><%= post.user.name %></strong>
           <% end %>
-
           <% if post.user_id == current_user.id %>
             <%= link_to post_path(post), method: :delete, class: "ml-auto mx-0 my-auto" do %>
               <div class="delete-post-icon">
               </div>
             <% end %>
           <% end %>
-
         </div>
-
         <%= link_to(post_path(post)) do %>
           <%= image_tag post.photos.first.image.url(:medium), class: "card-img-top" %>
         <% end %>
-
         <div class="card-body">
           <div class="row parts">
-
             <div id="like-icon-post-<%= post.id.to_s %>">
               <% if post.liked_by(current_user).present? %>
                 <%= link_to "いいねを取り消す", post_like_path(post.id, post.liked_by(current_user)), method: :DELETE, remote: true, class: "loved hide-text" %>
@@ -34,19 +29,23 @@
                 <%= link_to "いいね", post_likes_path(post), method: :POST, remote: true, class: "love hide-text" %>
               <% end %>
             </div>
-
             <%= link_to "", "#", class: "comment" %>
           </div>
-
           <div id="like-text-post-<%= post.id.to_s %>">
             <%= render "like_text", { likes: post.likes } %>
           </div>
-
           <div>
             <span><strong><%= post.user.name %></strong></span>
-            <span><%= render_with_hashtags(post.caption) %></span>
+            <span>
+              <% if post.caption.match(/[#＃]/) %>
+                <% render_with_hashtags(post.caption).each do |word| %>
+                  <%= p word %>
+                <% end %>
+              <% else %>
+                <%= p post.caption %>
+              <% end %>
+            </span>
             <%= link_to time_ago_in_words(post.created_at).upcase + "前", post_path(post), class: "post-time no-text-decoration" %>
-            
             <div id="comment-post-<%= post.id.to_s %>">
               <%= render 'comment_list', { post: post } %>
             </div>
@@ -60,7 +59,6 @@
                 <%= f.text_field :comment, class: "form-control comment-input border-0", placeholder: "コメント ...", autocomplete: :off %>
               <% end %>
             </div>
-
           </div>
         </div>
       </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,12 +25,8 @@
           </div>
           <div class="m-2">
             <strong>
-              <% if @post.caption.match(/[#＃]/) %>
-                <% render_with_hashtags(@post.caption).each do |word| %>
-                  <%= p word %>
-                <% end %>
-              <% else %>
-                <%= p @post.caption %>
+              <% return_an_array(@post.caption).each do |word| %>
+                <%= p word %>
               <% end %>
             </strong>
           </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,13 @@
           </div>
           <div class="m-2">
             <strong>
-              <%= render_with_hashtags(@post.caption) %>
+              <% if @post.caption.match(/[#＃]/) %>
+                <% render_with_hashtags(@post.caption).each do |word| %>
+                  <%= p word %>
+                <% end %>
+              <% else %>
+                <%= p @post.caption %>
+              <% end %>
             </strong>
           </div>
           <div class="comment-post-id">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,7 @@
           </div>
           <div class="m-2">
             <strong>
-              <% output_array(@post.caption).each do |word| %>
+              <% caption_and_hashtags_in_array(@post.caption).each do |word| %>
                 <%= word %>
               <% end %>
             </strong>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -16,34 +16,27 @@
               title: @post.user.name do %>
               <strong><%= @post.user.name %></strong>
             <% end %>
-
             <% if @post.user_id == current_user.id %>
               <%= link_to post_path(@post), method: :delete, class: "ml-auto mx-0 my-auto" do %>
                 <div class="delete-post-icon">
                 </div>
               <% end %>
             <% end %>
-
           </div>
           <div class="m-2">
             <strong>
-              
               <%= render_with_hashtags(@post.caption) %>
-              
             </strong>
           </div>
           <div class="comment-post-id">
             <div class="m-2">
-
               <div id="comment-post-<%= @post.id.to_s %>">
                 <%= render 'comment_list', post: @post %>
               </div>
-
             </div>
           </div>
         </div>
         <div class="row parts">
-
           <div id="like-icon-post-<%= @post.id.to_s %>">
             <% if @post.liked_by(current_user).present? %>
               <%= link_to "いいねを取り消す", post_like_path(@post.id, @post.liked_by(current_user)), method: :DELETE, remote: true, class: "loved hide-text" %>
@@ -51,16 +44,12 @@
               <%= link_to "いいね", post_likes_path(@post), method: :POST, remote: true, class: "love hide-text" %>
             <% end %>
           </div>
-
         </div>
-
         <div id="like-text-post-<%= @post.id.to_s %>">
           <%= render "like_text", { likes: @post.likes } %>
         </div>
-
         <div class="post-time"><%= time_ago_in_words(@post.created_at).upcase %>前</div>
         <hr>
-
         <div class="row parts" id="comment-form-post-<%= @post.id.to_s %>">
           <%= form_with model: [@post, Comment.new], local: false, class: "w-100" do |f| %>
             <%= f.hidden_field :user_id, value: current_user.id %>
@@ -68,7 +57,6 @@
             <%= f.text_field :comment, class: "form-control comment-input border-0", placeholder: "コメント ...", autocomplete: :off %>
           <% end %>
         </div>
-
       </div>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,7 +27,9 @@
           </div>
           <div class="m-2">
             <strong>
-              <%= @post.caption %>
+              
+              <%= render_with_hashtags(@post.caption) %>
+              
             </strong>
           </div>
           <div class="comment-post-id">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,8 +25,8 @@
           </div>
           <div class="m-2">
             <strong>
-              <% return_an_array(@post.caption).each do |word| %>
-                <%= p word %>
+              <% output_array(@post.caption).each do |word| %>
+                <%= word %>
               <% end %>
             </strong>
           </div>


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/GENKI112/Shirostagram2/issues/5#issue-816464304

## やったこと

* ハッシュタグをキャプションの中に書き込むと、#以降の文字を認識しDBに保存、そしてビュー（一覧でも詳細ページでも）にハッシュタグのリンクが作られるところまで実装しました。

## やらないこと

* ビューに反映されたハッシュタグをクリックした後のルーティングの設定、及びその後の動作。

## できるようになること（ユーザ目線）

* キャプションの中にハッシュタグを埋め込むことができるようになりました。

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 一通りの機能が使えるかチェックしました。ハッシュタグも打ち込むことができ、DBに保存されました。
* しかし、`dependent: :destroy`を設定しているにも関わらず、投稿の削除を行った時にタグをDBから削除することができませんでした。

## その他

* 前述した通り、DBから削除する機能ができておりません。
